### PR TITLE
Consultar compras recentes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/br/com/zupacademy/ggwadera/transacoes/estabelecimento/EstabelecimentoResponse.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/transacoes/estabelecimento/EstabelecimentoResponse.java
@@ -1,0 +1,26 @@
+package br.com.zupacademy.ggwadera.transacoes.estabelecimento;
+
+public class EstabelecimentoResponse {
+
+    private final String nome;
+    private final String cidade;
+    private final String endereco;
+
+    public EstabelecimentoResponse(Estabelecimento estabelecimento) {
+        this.nome = estabelecimento.getNome();
+        this.cidade = estabelecimento.getCidade();
+        this.endereco = estabelecimento.getEndereco();
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public String getCidade() {
+        return cidade;
+    }
+
+    public String getEndereco() {
+        return endereco;
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/transacoes/transacao/TransacaoController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/transacoes/transacao/TransacaoController.java
@@ -1,0 +1,32 @@
+package br.com.zupacademy.ggwadera.transacoes.transacao;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@RestController
+public class TransacaoController {
+
+    private final TransacaoRepository repository;
+
+    public TransacaoController(TransacaoRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping("/transacoes/{cartaoId}")
+    public ResponseEntity<List<TransacaoResponse>> ultimasTransacoes(@PathVariable UUID cartaoId) {
+        List<Transacao> transacoes = repository.findFirst10ByCartaoIdOrderByEfetivadaEmDesc(cartaoId);
+        if (transacoes.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        List<TransacaoResponse> responses = transacoes.stream()
+            .map(TransacaoResponse::new)
+            .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/transacoes/transacao/TransacaoRepository.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/transacoes/transacao/TransacaoRepository.java
@@ -2,7 +2,9 @@ package br.com.zupacademy.ggwadera.transacoes.transacao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface TransacaoRepository extends JpaRepository<Transacao, UUID> {
+    List<Transacao> findFirst10ByCartaoIdOrderByEfetivadaEmDesc(UUID cartaoId);
 }

--- a/src/main/java/br/com/zupacademy/ggwadera/transacoes/transacao/TransacaoResponse.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/transacoes/transacao/TransacaoResponse.java
@@ -1,0 +1,38 @@
+package br.com.zupacademy.ggwadera.transacoes.transacao;
+
+import br.com.zupacademy.ggwadera.transacoes.estabelecimento.EstabelecimentoResponse;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class TransacaoResponse {
+
+    private final UUID id;
+    private final BigDecimal valor;
+    private final LocalDateTime efetivadaEm;
+    private final EstabelecimentoResponse estabelecimento;
+
+    public TransacaoResponse(Transacao transacao) {
+        this.id = transacao.getId();
+        this.valor = transacao.getValor();
+        this.efetivadaEm = transacao.getEfetivadaEm();
+        this.estabelecimento = new EstabelecimentoResponse(transacao.getEstabelecimento());
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public BigDecimal getValor() {
+        return valor;
+    }
+
+    public LocalDateTime getEfetivadaEm() {
+        return efetivadaEm;
+    }
+
+    public EstabelecimentoResponse getEstabelecimento() {
+        return estabelecimento;
+    }
+}


### PR DESCRIPTION
## Objetivo

Buscar as últimas transações do cartão de crédito.

## Necessidades

O portador do cartão deseja realizar uma consulta para obter as últimas compras do cartão de crédito.

## Restrições

Devemos criar uma API com as seguintes restrições:

- Identificador do cartão é obrigatório e deve ser informado na URL (path parameter).

## Resultado Esperado

- Retornar status code **200** com as últimas 10 compras (transações)
- Retornar status code **404** quando o cartão não for encontrado.